### PR TITLE
feat: add weekly crypto mining and live markets

### DIFF
--- a/app/computer/crypto.tsx
+++ b/app/computer/crypto.tsx
@@ -1,17 +1,16 @@
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import BackButton from '../../src/components/BackButton';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useToast } from '../../src/ui/Toast';
 import { useGame } from '../../src/store';
+import type { Coin } from '../../src/types';
 
 const COINS = ['BTC','ETH','SOL','BNB','XRP'] as const;
-type Coin = typeof COINS[number];
-
 const MINERS = [
   { id:'USB_MINER',   name:'USB Miner',     price:120,  hash:  5 },
   { id:'GPU_RIG',     name:'GPU Rig',       price:800,  hash: 40 },
   { id:'ASIC_LITE',   name:'ASIC Lite',     price:1600, hash: 90 },
-  { id:'ASIC_PRO',    name:'ASIC Pro',      price:3200, hash: 200 },
+  { id:'ASIC_PRO',    name:'ASIC Pro',      price:3200, hash:200 },
 ];
 
 export default function Crypto() {
@@ -19,12 +18,32 @@ export default function Crypto() {
   const show = useToast(t=>t.show);
   const [tab, setTab] = useState<'MINING'|'MARKET'>('MINING');
 
-  // simple in‑component state until store actions are added
-  const [target, setTarget] = useState<Coin>('BTC');
-  const [owned, setOwned] = useState<string[]>([]);
-  const [balances, setBalances] = useState<Record<Coin, number>>({ BTC:0, ETH:0, SOL:0, BNB:0, XRP:0 });
+  const totalHash = Object.entries(s.cryptoMiners).reduce((a,[id,count])=>{
+    const def = MINERS.find(m=>m.id===id); return a + (def?def.hash*count:0);
+  },0);
+  const est = totalHash/1000;
 
-  const totalHash = owned.reduce((a,id)=>a+(MINERS.find(m=>m.id===id)?.hash||0),0);
+  const [market,setMarket] = useState<Record<Coin,{price:number, history:number[]}>>(
+    COINS.reduce((acc,c)=>({ ...acc, [c]:{ price:1000+Math.random()*8000, history:[] } }),{} as any)
+  );
+
+  useEffect(()=>{
+    const update=()=>{
+      setMarket(m=>{
+        const next={...m};
+        COINS.forEach(c=>{
+          const prev=next[c].price;
+          const price=Math.max(1, prev*(1+(Math.random()-0.5)/20));
+          const history=[...next[c].history, price].slice(-20);
+          next[c]={price, history};
+        });
+        return next;
+      });
+    };
+    update();
+    const id=setInterval(update,30000);
+    return ()=>clearInterval(id);
+  },[]);
 
   return (
     <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
@@ -41,69 +60,72 @@ export default function Crypto() {
           <Text style={{ fontWeight:'800' }}>Choose Coin to Mine</Text>
           <View style={{ flexDirection:'row', flexWrap:'wrap', gap:8 }}>
             {COINS.map(c=>(
-              <Pressable key={c} onPress={()=>setTarget(c)} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: target===c ? '#111827' : '#e5e7eb' }}>
-                <Text style={{ color: target===c ? '#fff' : '#111827', fontWeight:'800' }}>{c}</Text>
+              <Pressable key={c} onPress={()=>s.setCryptoTarget(c)} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: s.cryptoTarget===c ? '#111827' : '#e5e7eb' }}>
+                <Text style={{ color: s.cryptoTarget===c ? '#fff' : '#111827', fontWeight:'800' }}>{c}</Text>
               </Pressable>
             ))}
           </View>
 
-          <Text style={{ marginTop:8, color:'#6b7280' }}>Hashrate: <Text style={{ fontWeight:'800', color:'#111827' }}>{totalHash} H/s</Text></Text>
+          <Text style={{ marginTop:8, color:'#6b7280' }}>
+            Hashrate: <Text style={{ fontWeight:'800', color:'#111827' }}>{totalHash} H/s</Text> (≈ {est.toFixed(4)} {s.cryptoTarget}/week)
+          </Text>
 
           <Text style={{ marginTop:8, fontWeight:'800' }}>Miners</Text>
-          {MINERS.map(m=> {
-            const have = owned.includes(m.id);
+          {MINERS.map(m=>{
+            const count = s.cryptoMiners[m.id] || 0;
             return (
               <View key={m.id} style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, flexDirection:'row', justifyContent:'space-between', alignItems:'center' }}>
                 <View>
                   <Text style={{ fontWeight:'800' }}>{m.name}</Text>
                   <Text style={{ color:'#6b7280' }}>{m.hash} H/s</Text>
+                  {count>0 && <Text style={{ color:'#6b7280' }}>Qty: {count}</Text>}
                 </View>
                 <Pressable
-                  onPress={()=>{ setOwned(o=>[...o,m.id]); show(`Bought ${m.name}`); }}
-                  disabled={have}
-                  style={{ backgroundColor: have ? '#e5e7eb' : '#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
+                  onPress={()=>{ s.buyMiner(m.id); if(s.money>=m.price) show(`Bought ${m.name}`); }}
+                  style={{ backgroundColor:'#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
                 >
-                  <Text style={{ color: have ? '#6b7280' : '#fff', fontWeight:'800' }}>
-                    {have ? 'Owned' : `$${m.price}`}
-                  </Text>
+                  <Text style={{ color:'#fff', fontWeight:'800' }}>${m.price}</Text>
                 </Pressable>
               </View>
             );
           })}
-
-          <Pressable
-            onPress={()=>{
-              // super simple weekly mining: coins += hash/1000
-              setBalances(b => ({ ...b, [target]: (b[target] ?? 0) + totalHash/1000 }));
-              show(`Mined ${ (totalHash/1000).toFixed(4) } ${target}`);
-            }}
-            style={{ alignSelf:'flex-start', backgroundColor:'#2563eb', paddingHorizontal:12, paddingVertical:10, borderRadius:12 }}
-          >
-            <Text style={{ color:'#fff', fontWeight:'800' }}>Mine Now</Text>
-          </Pressable>
-
-          <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12 }}>
-            <Text style={{ fontWeight:'800' }}>Balances</Text>
-            {COINS.map(c=> <Text key={c}>{c}: {balances[c]?.toFixed(4) ?? 0}</Text>)}
-          </View>
         </View>
       )}
 
       {tab==='MARKET' && (
-        <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, gap:8 }}>
-          <Text style={{ fontWeight:'800' }}>Top 5 Coins (mock)</Text>
-          {COINS.map(c=>(
-            <View key={c} style={{ flexDirection:'row', justifyContent:'space-between' }}>
-              <Text>{c}</Text>
-              <Text style={{ color:'#16a34a', fontWeight:'800' }}>${(1000 + Math.random()*8000 | 0)}</Text>
-            </View>
-          ))}
-          <Text style={{ color:'#6b7280' }}>Hook into real pricing later if desired.</Text>
+        <View style={{ gap:12 }}>
+          {COINS.map(c=>{
+            const data=market[c];
+            const history=data.history;
+            const prev=history[history.length-2] || data.price;
+            const pct=((data.price-prev)/prev)*100;
+            const holding=s.cryptoPortfolio[c]||0;
+            return (
+              <View key={c} style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, marginBottom:8 }}>
+                <View style={{ flexDirection:'row', justifyContent:'space-between', alignItems:'center' }}>
+                  <Text style={{ fontWeight:'800' }}>{c}</Text>
+                  <Text style={{ fontWeight:'800', color: pct>=0 ? '#16a34a' : '#dc2626' }}>${data.price.toFixed(2)} ({pct>=0?'+':''}{pct.toFixed(2)}%)</Text>
+                </View>
+                <View style={{ flexDirection:'row', height:30, marginTop:4 }}>
+                  {history.map((p,i)=>{ const max=Math.max(...history, data.price); const h=(p/max)*30; return <View key={i} style={{ width:4, height:h, backgroundColor:'#2563eb', marginRight:1, alignSelf:'flex-end' }} />; })}
+                </View>
+                <View style={{ flexDirection:'row', justifyContent:'space-between', marginTop:8, alignItems:'center' }}>
+                  <Text>Holding: {holding.toFixed(4)}</Text>
+                  {holding>0 && (
+                    <Pressable onPress={()=>{ s.sellCrypto(c, holding, data.price); show(`Sold ${holding.toFixed(4)} ${c}`); }} style={{ backgroundColor:'#dc2626', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
+                      <Text style={{ color:'#fff', fontWeight:'800' }}>Sell All</Text>
+                    </Pressable>
+                  )}
+                </View>
+              </View>
+            );
+          })}
         </View>
       )}
     </ScrollView>
   );
 }
+
 function TabBtn({ label, active, onPress }:{ label:string; active:boolean; onPress:()=>void }) {
   return (
     <Pressable onPress={onPress} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: active ? '#111827' : '#e5e7eb' }}>

--- a/app/computer/stocks.tsx
+++ b/app/computer/stocks.tsx
@@ -1,28 +1,55 @@
-import { View, Text, Pressable, ScrollView } from 'react-native';
+import { View, Text, ScrollView } from 'react-native';
 import BackButton from '../../src/components/BackButton';
-import { useToast } from '../../src/ui/Toast';
+import { useEffect, useState } from 'react';
 
-const TICKERS = ['AAPL','MSFT','NVDA','AMZN','META'];
+const TICKERS = ['AAPL','MSFT','NVDA','AMZN','META'] as const;
+type Ticker = typeof TICKERS[number];
 
 export default function Stocks() {
-  const show = useToast(t=>t.show);
+  const [market,setMarket] = useState<Record<Ticker,{price:number, history:number[]}>>(
+    TICKERS.reduce((a,t)=>({ ...a, [t]:{ price:50+Math.random()*900, history:[] } }),{} as any)
+  );
+
+  useEffect(()=>{
+    const update = () => {
+      setMarket(m=>{
+        const next={...m};
+        TICKERS.forEach(t=>{
+          const prev=next[t].price;
+          const price=Math.max(1, prev*(1+(Math.random()-0.5)/20));
+          const history=[...next[t].history, price].slice(-20);
+          next[t]={price, history};
+        });
+        return next;
+      });
+    };
+    update();
+    const id=setInterval(update,30000);
+    return ()=>clearInterval(id);
+  },[]);
+
   return (
     <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
       <BackButton label="Back to Apps" />
       <Text style={{ fontSize:22, fontWeight:'900' }}>Stocks</Text>
 
-      <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12 }}>
-        <Text style={{ fontWeight:'800' }}>Watchlist (mock)</Text>
-        {TICKERS.map(t=>(
-          <View key={t} style={{ flexDirection:'row', justifyContent:'space-between', paddingVertical:6 }}>
-            <Text>{t}</Text>
-            <Text style={{ color:'#16a34a', fontWeight:'800' }}>${(50 + Math.random()*900 | 0)}</Text>
+      {TICKERS.map(t=>{
+        const data=market[t];
+        const history=data.history;
+        const prev=history[history.length-2] || data.price;
+        const pct=((data.price-prev)/prev)*100;
+        return (
+          <View key={t} style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, marginBottom:8 }}>
+            <View style={{ flexDirection:'row', justifyContent:'space-between', alignItems:'center' }}>
+              <Text style={{ fontWeight:'800' }}>{t}</Text>
+              <Text style={{ fontWeight:'800', color: pct>=0 ? '#16a34a' : '#dc2626' }}>${data.price.toFixed(2)} ({pct>=0?'+':''}{pct.toFixed(2)}%)</Text>
+            </View>
+            <View style={{ flexDirection:'row', height:30, marginTop:4 }}>
+              {history.map((p,i)=>{ const max=Math.max(...history, data.price); const h=(p/max)*30; return <View key={i} style={{ width:4, height:h, backgroundColor:'#2563eb', marginRight:1, alignSelf:'flex-end' }} />; })}
+            </View>
           </View>
-        ))}
-        <Pressable onPress={()=>show('Order placed (mock)')} style={{ marginTop:8, alignSelf:'flex-start', backgroundColor:'#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
-          <Text style={{ color:'#fff', fontWeight:'800' }}>Buy AAPL</Text>
-        </Pressable>
-      </View>
+        );
+      })}
     </ScrollView>
   );
 }

--- a/app/mobile/crypto.tsx
+++ b/app/mobile/crypto.tsx
@@ -1,17 +1,16 @@
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import BackButton from '../../src/components/BackButton';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useToast } from '../../src/ui/Toast';
 import { useGame } from '../../src/store';
+import type { Coin } from '../../src/types';
 
 const COINS = ['BTC','ETH','SOL','BNB','XRP'] as const;
-type Coin = typeof COINS[number];
-
 const MINERS = [
   { id:'USB_MINER',   name:'USB Miner',     price:120,  hash:  5 },
   { id:'GPU_RIG',     name:'GPU Rig',       price:800,  hash: 40 },
   { id:'ASIC_LITE',   name:'ASIC Lite',     price:1600, hash: 90 },
-  { id:'ASIC_PRO',    name:'ASIC Pro',      price:3200, hash: 200 },
+  { id:'ASIC_PRO',    name:'ASIC Pro',      price:3200, hash:200 },
 ];
 
 export default function Crypto() {
@@ -19,16 +18,36 @@ export default function Crypto() {
   const show = useToast(t=>t.show);
   const [tab, setTab] = useState<'MINING'|'MARKET'>('MINING');
 
-  // simple in‑component state until store actions are added
-  const [target, setTarget] = useState<Coin>('BTC');
-  const [owned, setOwned] = useState<string[]>([]);
-  const [balances, setBalances] = useState<Record<Coin, number>>({ BTC:0, ETH:0, SOL:0, BNB:0, XRP:0 });
+  const totalHash = Object.entries(s.cryptoMiners).reduce((a,[id,count])=>{
+    const def = MINERS.find(m=>m.id===id); return a + (def?def.hash*count:0);
+  },0);
+  const est = totalHash/1000;
 
-  const totalHash = owned.reduce((a,id)=>a+(MINERS.find(m=>m.id===id)?.hash||0),0);
+  const [market,setMarket] = useState<Record<Coin,{price:number, history:number[]}>>(
+    COINS.reduce((acc,c)=>({ ...acc, [c]:{ price:1000+Math.random()*8000, history:[] } }),{} as any)
+  );
+
+  useEffect(()=>{
+    const update=()=>{
+      setMarket(m=>{
+        const next={...m};
+        COINS.forEach(c=>{
+          const prev=next[c].price;
+          const price=Math.max(1, prev*(1+(Math.random()-0.5)/20));
+          const history=[...next[c].history, price].slice(-20);
+          next[c]={price, history};
+        });
+        return next;
+      });
+    };
+    update();
+    const id=setInterval(update,30000);
+    return ()=>clearInterval(id);
+  },[]);
 
   return (
     <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
-      <BackButton label="Back to Apps" />
+      <BackButton label="Back" />
       <Text style={{ fontSize:22, fontWeight:'900' }}>Crypto</Text>
 
       <View style={{ flexDirection:'row', gap:8 }}>
@@ -41,69 +60,72 @@ export default function Crypto() {
           <Text style={{ fontWeight:'800' }}>Choose Coin to Mine</Text>
           <View style={{ flexDirection:'row', flexWrap:'wrap', gap:8 }}>
             {COINS.map(c=>(
-              <Pressable key={c} onPress={()=>setTarget(c)} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: target===c ? '#111827' : '#e5e7eb' }}>
-                <Text style={{ color: target===c ? '#fff' : '#111827', fontWeight:'800' }}>{c}</Text>
+              <Pressable key={c} onPress={()=>s.setCryptoTarget(c)} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: s.cryptoTarget===c ? '#111827' : '#e5e7eb' }}>
+                <Text style={{ color: s.cryptoTarget===c ? '#fff' : '#111827', fontWeight:'800' }}>{c}</Text>
               </Pressable>
             ))}
           </View>
 
-          <Text style={{ marginTop:8, color:'#6b7280' }}>Hashrate: <Text style={{ fontWeight:'800', color:'#111827' }}>{totalHash} H/s</Text></Text>
+          <Text style={{ marginTop:8, color:'#6b7280' }}>
+            Hashrate: <Text style={{ fontWeight:'800', color:'#111827' }}>{totalHash} H/s</Text> (≈ {est.toFixed(4)} {s.cryptoTarget}/week)
+          </Text>
 
           <Text style={{ marginTop:8, fontWeight:'800' }}>Miners</Text>
-          {MINERS.map(m=> {
-            const have = owned.includes(m.id);
+          {MINERS.map(m=>{
+            const count = s.cryptoMiners[m.id] || 0;
             return (
               <View key={m.id} style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, flexDirection:'row', justifyContent:'space-between', alignItems:'center' }}>
                 <View>
                   <Text style={{ fontWeight:'800' }}>{m.name}</Text>
                   <Text style={{ color:'#6b7280' }}>{m.hash} H/s</Text>
+                  {count>0 && <Text style={{ color:'#6b7280' }}>Qty: {count}</Text>}
                 </View>
                 <Pressable
-                  onPress={()=>{ setOwned(o=>[...o,m.id]); show(`Bought ${m.name}`); }}
-                  disabled={have}
-                  style={{ backgroundColor: have ? '#e5e7eb' : '#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
+                  onPress={()=>{ s.buyMiner(m.id); if(s.money>=m.price) show(`Bought ${m.name}`); }}
+                  style={{ backgroundColor:'#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
                 >
-                  <Text style={{ color: have ? '#6b7280' : '#fff', fontWeight:'800' }}>
-                    {have ? 'Owned' : `$${m.price}`}
-                  </Text>
+                  <Text style={{ color:'#fff', fontWeight:'800' }}>${m.price}</Text>
                 </Pressable>
               </View>
             );
           })}
-
-          <Pressable
-            onPress={()=>{
-              // super simple weekly mining: coins += hash/1000
-              setBalances(b => ({ ...b, [target]: (b[target] ?? 0) + totalHash/1000 }));
-              show(`Mined ${ (totalHash/1000).toFixed(4) } ${target}`);
-            }}
-            style={{ alignSelf:'flex-start', backgroundColor:'#2563eb', paddingHorizontal:12, paddingVertical:10, borderRadius:12 }}
-          >
-            <Text style={{ color:'#fff', fontWeight:'800' }}>Mine Now</Text>
-          </Pressable>
-
-          <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12 }}>
-            <Text style={{ fontWeight:'800' }}>Balances</Text>
-            {COINS.map(c=> <Text key={c}>{c}: {balances[c]?.toFixed(4) ?? 0}</Text>)}
-          </View>
         </View>
       )}
 
       {tab==='MARKET' && (
-        <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, gap:8 }}>
-          <Text style={{ fontWeight:'800' }}>Top 5 Coins (mock)</Text>
-          {COINS.map(c=>(
-            <View key={c} style={{ flexDirection:'row', justifyContent:'space-between' }}>
-              <Text>{c}</Text>
-              <Text style={{ color:'#16a34a', fontWeight:'800' }}>${(1000 + Math.random()*8000 | 0)}</Text>
-            </View>
-          ))}
-          <Text style={{ color:'#6b7280' }}>Hook into real pricing later if desired.</Text>
+        <View style={{ gap:12 }}>
+          {COINS.map(c=>{
+            const data=market[c];
+            const history=data.history;
+            const prev=history[history.length-2] || data.price;
+            const pct=((data.price-prev)/prev)*100;
+            const holding=s.cryptoPortfolio[c]||0;
+            return (
+              <View key={c} style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, marginBottom:8 }}>
+                <View style={{ flexDirection:'row', justifyContent:'space-between', alignItems:'center' }}>
+                  <Text style={{ fontWeight:'800' }}>{c}</Text>
+                  <Text style={{ fontWeight:'800', color: pct>=0 ? '#16a34a' : '#dc2626' }}>${data.price.toFixed(2)} ({pct>=0?'+':''}{pct.toFixed(2)}%)</Text>
+                </View>
+                <View style={{ flexDirection:'row', height:30, marginTop:4 }}>
+                  {history.map((p,i)=>{ const max=Math.max(...history, data.price); const h=(p/max)*30; return <View key={i} style={{ width:4, height:h, backgroundColor:'#2563eb', marginRight:1, alignSelf:'flex-end' }} />; })}
+                </View>
+                <View style={{ flexDirection:'row', justifyContent:'space-between', marginTop:8, alignItems:'center' }}>
+                  <Text>Holding: {holding.toFixed(4)}</Text>
+                  {holding>0 && (
+                    <Pressable onPress={()=>{ s.sellCrypto(c, holding, data.price); show(`Sold ${holding.toFixed(4)} ${c}`); }} style={{ backgroundColor:'#dc2626', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
+                      <Text style={{ color:'#fff', fontWeight:'800' }}>Sell All</Text>
+                    </Pressable>
+                  )}
+                </View>
+              </View>
+            );
+          })}
         </View>
       )}
     </ScrollView>
   );
 }
+
 function TabBtn({ label, active, onPress }:{ label:string; active:boolean; onPress:()=>void }) {
   return (
     <Pressable onPress={onPress} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: active ? '#111827' : '#e5e7eb' }}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
 export type Perk = 'WORK_PAY' | 'MINDSET' | 'FAST_LEARNER' | 'GOOD_CREDIT';
 
+export type Coin = 'BTC' | 'ETH' | 'SOL' | 'BNB' | 'XRP';
+export type Ticker = 'AAPL' | 'MSFT' | 'NVDA' | 'AMZN' | 'META';
+
 export interface Skills { coding: number; business: number; social: number; fitness: number; hacking: number; }
 
 export interface Job {
@@ -103,6 +106,11 @@ export interface GameState {
   ownedItems: string[];
   foods: Food[];
   shopItems: ShopItem[];
+
+  cryptoTarget: Coin;
+  cryptoPortfolio: Record<Coin, number>;
+  cryptoMiners: Record<string, number>;
+  stockPortfolio: Record<Ticker, number>;
 
   // buffs from weekly eBay items
   activeBuffs: MarketBuff[];


### PR DESCRIPTION
## Summary
- track crypto miners and portfolio in global state
- mine selected coin on weekly tick with automatic payouts
- add live-updating crypto and stock market screens with basic sparklines and selling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68990c265904832cb817518324237010