### PR TITLE
Improve app scrolling and expand business and markets

### DIFF
--- a/app/mobile/crypto.tsx
+++ b/app/mobile/crypto.tsx
@@ -1,30 +1,50 @@
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import BackButton from '../../src/components/BackButton';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useToast } from '../../src/ui/Toast';
 import { useGame } from '../../src/store';
-
-const COINS = ['BTC','ETH','SOL','BNB','XRP'] as const;
-type Coin = typeof COINS[number];
-
-const MINERS = [
-  { id:'USB_MINER',   name:'USB Miner',     price:120,  hash:  5 },
-  { id:'GPU_RIG',     name:'GPU Rig',       price:800,  hash: 40 },
-  { id:'ASIC_LITE',   name:'ASIC Lite',     price:1600, hash: 90 },
-  { id:'ASIC_PRO',    name:'ASIC Pro',      price:3200, hash: 200 },
-];
+import { COINS, MINERS, Coin } from '../../src/data/crypto';
 
 export default function Crypto() {
-  const s = useGame();
+  const {
+    cryptoTarget, setMiningTarget,
+    cryptoMiners, buyMiner,
+    cryptoPortfolio,
+  } = useGame();
   const show = useToast(t=>t.show);
   const [tab, setTab] = useState<'MINING'|'MARKET'>('MINING');
 
-  // simple in‑component state until store actions are added
-  const [target, setTarget] = useState<Coin>('BTC');
-  const [owned, setOwned] = useState<string[]>([]);
-  const [balances, setBalances] = useState<Record<Coin, number>>({ BTC:0, ETH:0, SOL:0, BNB:0, XRP:0 });
+  const totalHash = cryptoMiners.reduce((a,m)=>{
+    const def = MINERS.find(d=>d.id===m.id); return a + (def ? def.hash*m.count : 0);
+  },0);
+  const estEarn = (totalHash/1000).toFixed(4);
 
-  const totalHash = owned.reduce((a,id)=>a+(MINERS.find(m=>m.id===id)?.hash||0),0);
+  const [prices, setPrices] = useState<Record<Coin,{price:number; prev:number; hist:number[]}>>(()=>{
+    const obj:any={};
+    COINS.forEach(c=>obj[c]={price:1000, prev:1000, hist:[1000]});
+    return obj;
+  });
+  useEffect(()=>{
+    const iv = setInterval(()=>{
+      setPrices(p=>{
+        const next:any={};
+        COINS.forEach(c=>{
+          const old = p[c];
+          const price = Math.max(1, old.price*(1+(Math.random()-0.5)/20));
+          const hist = [...old.hist, price].slice(-10);
+          next[c]={price, prev:old.price, hist};
+        });
+        return next;
+      });
+    },30000);
+    return ()=>clearInterval(iv);
+  },[]);
+
+  const spark = (vals:number[])=>{
+    const chars=['▁','▂','▃','▄','▅','▆','▇'];
+    const min=Math.min(...vals); const max=Math.max(...vals); const span=max-min||1;
+    return vals.map(v=>chars[Math.floor((v-min)/span*(chars.length-1))]).join('');
+  };
 
   return (
     <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
@@ -41,64 +61,60 @@ export default function Crypto() {
           <Text style={{ fontWeight:'800' }}>Choose Coin to Mine</Text>
           <View style={{ flexDirection:'row', flexWrap:'wrap', gap:8 }}>
             {COINS.map(c=>(
-              <Pressable key={c} onPress={()=>setTarget(c)} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: target===c ? '#111827' : '#e5e7eb' }}>
-                <Text style={{ color: target===c ? '#fff' : '#111827', fontWeight:'800' }}>{c}</Text>
+              <Pressable key={c} onPress={()=>setMiningTarget(c)} style={{ paddingHorizontal:12, paddingVertical:8, borderRadius:10, backgroundColor: cryptoTarget===c ? '#111827' : '#e5e7eb' }}>
+                <Text style={{ color: cryptoTarget===c ? '#fff' : '#111827', fontWeight:'800' }}>{c}</Text>
               </Pressable>
             ))}
           </View>
 
-          <Text style={{ marginTop:8, color:'#6b7280' }}>Hashrate: <Text style={{ fontWeight:'800', color:'#111827' }}>{totalHash} H/s</Text></Text>
+          <Text style={{ marginTop:8, color:'#6b7280' }}>Hashrate: <Text style={{ fontWeight:'800', color:'#111827' }}>{totalHash} H/s</Text> (~{estEarn} {cryptoTarget}/week)</Text>
 
           <Text style={{ marginTop:8, fontWeight:'800' }}>Miners</Text>
           {MINERS.map(m=> {
-            const have = owned.includes(m.id);
+            const count = cryptoMiners.find(x=>x.id===m.id)?.count ?? 0;
             return (
               <View key={m.id} style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, flexDirection:'row', justifyContent:'space-between', alignItems:'center' }}>
                 <View>
                   <Text style={{ fontWeight:'800' }}>{m.name}</Text>
-                  <Text style={{ color:'#6b7280' }}>{m.hash} H/s</Text>
+                  <Text style={{ color:'#6b7280' }}>{m.hash} H/s each • Owned {count}</Text>
                 </View>
                 <Pressable
-                  onPress={()=>{ setOwned(o=>[...o,m.id]); show(`Bought ${m.name}`); }}
-                  disabled={have}
-                  style={{ backgroundColor: have ? '#e5e7eb' : '#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
+                  onPress={()=>{ buyMiner(m.id); show(`Bought ${m.name}`); }}
+                  style={{ backgroundColor:'#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
                 >
-                  <Text style={{ color: have ? '#6b7280' : '#fff', fontWeight:'800' }}>
-                    {have ? 'Owned' : `$${m.price}`}
-                  </Text>
+                  <Text style={{ color:'#fff', fontWeight:'800' }}>${m.price}</Text>
                 </Pressable>
               </View>
             );
           })}
-
-          <Pressable
-            onPress={()=>{
-              // super simple weekly mining: coins += hash/1000
-              setBalances(b => ({ ...b, [target]: (b[target] ?? 0) + totalHash/1000 }));
-              show(`Mined ${ (totalHash/1000).toFixed(4) } ${target}`);
-            }}
-            style={{ alignSelf:'flex-start', backgroundColor:'#2563eb', paddingHorizontal:12, paddingVertical:10, borderRadius:12 }}
-          >
-            <Text style={{ color:'#fff', fontWeight:'800' }}>Mine Now</Text>
-          </Pressable>
-
-          <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12 }}>
-            <Text style={{ fontWeight:'800' }}>Balances</Text>
-            {COINS.map(c=> <Text key={c}>{c}: {balances[c]?.toFixed(4) ?? 0}</Text>)}
-          </View>
         </View>
       )}
 
       {tab==='MARKET' && (
         <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12, gap:8 }}>
-          <Text style={{ fontWeight:'800' }}>Top 5 Coins (mock)</Text>
-          {COINS.map(c=>(
-            <View key={c} style={{ flexDirection:'row', justifyContent:'space-between' }}>
-              <Text>{c}</Text>
-              <Text style={{ color:'#16a34a', fontWeight:'800' }}>${(1000 + Math.random()*8000 | 0)}</Text>
-            </View>
-          ))}
-          <Text style={{ color:'#6b7280' }}>Hook into real pricing later if desired.</Text>
+          <Text style={{ fontWeight:'800' }}>Market</Text>
+          {COINS.map(c=>{
+            const info = prices[c];
+            const change = ((info.price - info.prev)/info.prev)*100;
+            return (
+              <View key={c} style={{ marginBottom:6 }}>
+                <View style={{ flexDirection:'row', justifyContent:'space-between' }}>
+                  <Text>{c}</Text>
+                  <View style={{ alignItems:'flex-end' }}>
+                    <Text style={{ color: change>=0?'#16a34a':'#ef4444', fontWeight:'800' }}>${info.price.toFixed(2)}</Text>
+                    <Text style={{ color: change>=0?'#16a34a':'#ef4444' }}>{change.toFixed(2)}%</Text>
+                  </View>
+                </View>
+                <Text style={{ color:'#6b7280', fontSize:12 }}>{spark(info.hist)}</Text>
+              </View>
+            );
+          })}
+          <View style={{ marginTop:8 }}>
+            <Text style={{ fontWeight:'800' }}>Portfolio</Text>
+            {COINS.map(c=> (
+              <Text key={c}>{c}: {cryptoPortfolio[c]?.toFixed(4) ?? 0}</Text>
+            ))}
+          </View>
         </View>
       )}
     </ScrollView>

--- a/app/mobile/stocks.tsx
+++ b/app/mobile/stocks.tsx
@@ -1,24 +1,60 @@
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import BackButton from '../../src/components/BackButton';
 import { useToast } from '../../src/ui/Toast';
+import { useState, useEffect } from 'react';
 
 const TICKERS = ['AAPL','MSFT','NVDA','AMZN','META'];
 
 export default function Stocks() {
   const show = useToast(t=>t.show);
+  const [prices, setPrices] = useState<Record<string,{price:number; prev:number; hist:number[]}>>(()=>{
+    const obj:any={};
+    TICKERS.forEach(t=>{ const p=100+Math.random()*200; obj[t]={price:p, prev:p, hist:[p]}; });
+    return obj;
+  });
+  useEffect(()=>{
+    const iv=setInterval(()=>{
+      setPrices(p=>{
+        const next:any={};
+        TICKERS.forEach(t=>{
+          const old=p[t];
+          const price=Math.max(1, old.price*(1+(Math.random()-0.5)/20));
+          const hist=[...old.hist, price].slice(-10);
+          next[t]={price, prev:old.price, hist};
+        });
+        return next;
+      });
+    },30000);
+    return ()=>clearInterval(iv);
+  },[]);
+  const spark=(vals:number[])=>{
+    const chars=['▁','▂','▃','▄','▅','▆','▇'];
+    const min=Math.min(...vals); const max=Math.max(...vals); const span=max-min||1;
+    return vals.map(v=>chars[Math.floor((v-min)/span*(chars.length-1))]).join('');
+  };
   return (
     <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
       <BackButton label="Back to Apps" />
       <Text style={{ fontSize:22, fontWeight:'900' }}>Stocks</Text>
 
       <View style={{ backgroundColor:'#fff', borderRadius:12, borderWidth:1, borderColor:'#e5e7eb', padding:12 }}>
-        <Text style={{ fontWeight:'800' }}>Watchlist (mock)</Text>
-        {TICKERS.map(t=>(
-          <View key={t} style={{ flexDirection:'row', justifyContent:'space-between', paddingVertical:6 }}>
-            <Text>{t}</Text>
-            <Text style={{ color:'#16a34a', fontWeight:'800' }}>${(50 + Math.random()*900 | 0)}</Text>
-          </View>
-        ))}
+        <Text style={{ fontWeight:'800' }}>Watchlist</Text>
+        {TICKERS.map(t=>{
+          const info=prices[t];
+          const change=((info.price-info.prev)/info.prev)*100;
+          return (
+            <View key={t} style={{ paddingVertical:6 }}>
+              <View style={{ flexDirection:'row', justifyContent:'space-between' }}>
+                <Text>{t}</Text>
+                <View style={{ alignItems:'flex-end' }}>
+                  <Text style={{ color:change>=0?'#16a34a':'#ef4444', fontWeight:'800' }}>${info.price.toFixed(2)}</Text>
+                  <Text style={{ color:change>=0?'#16a34a':'#ef4444' }}>{change.toFixed(2)}%</Text>
+                </View>
+              </View>
+              <Text style={{ color:'#6b7280', fontSize:12 }}>{spark(info.hist)}</Text>
+            </View>
+          );
+        })}
         <Pressable onPress={()=>show('Order placed (mock)')} style={{ marginTop:8, alignSelf:'flex-start', backgroundColor:'#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
           <Text style={{ color:'#fff', fontWeight:'800' }}>Buy AAPL</Text>
         </Pressable>

--- a/src/apps/BusinessApp.tsx
+++ b/src/apps/BusinessApp.tsx
@@ -2,62 +2,40 @@ import { View, Text, Pressable, ScrollView } from 'react-native';
 import BackButton from '../components/BackButton';
 import { useGame } from '../store';
 import { useToast } from '../ui/Toast';
-
-const COMPANIES = [
-  { id:'FACTORY', name:'Factory', price:10000, baseRev:400 },
-  { id:'RESTAURANT', name:'Restaurant', price:6000, baseRev:250 },
-  { id:'AI_CO', name:'AI Company', price:15000, baseRev:600 },
-  { id:'REAL_ESTATE', name:'Real Estate', price:22000, baseRev:800 },
-  { id:'BANK', name:'Bank', price:30000, baseRev:1200 },
-];
+import { COMPANIES } from '../data/companies';
 
 export default function BusinessApp() {
-  const s = useGame();
-  const { money, companies } = s;
+  const {
+    money, companies, educations,
+    startCompany, hireEmployee,
+    upgradeMarketing, automateCompany,
+    upgradeCashflow,
+  } = useGame();
   const show = useToast(t=>t.show);
 
   const owns = (id:string) => companies.some(c=>c.id===id);
-  const canStart = (id:string) => s.educations.some(e=>e.id==='BUSINESS_101') && !owns(id);
-
-  const start = (id:string) => {
-    if (!canStart(id)) return;
-    const def = COMPANIES.find(c=>c.id===id)!;
-    if (s.money < def.price) return;
-    s.companies.push({ id:def.id, name:def.name, employees:0, revenuePerWeek:def.baseRev, costPerWeek: def.baseRev*0.2 });
-    s.money -= def.price;
-    show(`Started ${def.name}`);
-  };
-
-  const hire = (id:string) => {
-    const c = s.companies.find(x=>x.id===id); if (!c) return;
-    c.employees += 1; c.revenuePerWeek += 100; c.costPerWeek += 40;
-    show('Hired 1 employee');
-  };
-
-  const upgrade = (id:string, kind:'marketing'|'automation') => {
-    const c = s.companies.find(x=>x.id===id); if (!c) return;
-    if (kind==='marketing') c.revenuePerWeek += 150;
-    else c.costPerWeek = Math.max(0, c.costPerWeek - 20);
-    show(`Upgraded ${kind}`);
-  };
+  const hasEdu = educations.some(e=>e.id==='BUSINESS_101');
 
   return (
     <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
       <BackButton label="Back" />
       <Text style={{ fontSize:22, fontWeight:'900' }}>Companies</Text>
 
-      <Text style={{ color:'#6b7280' }}>Requires: <Text style={{ fontWeight:'800' }}>Business 101</Text></Text>
+      {!hasEdu && (
+        <Text style={{ color:'#6b7280' }}>Requires: <Text style={{ fontWeight:'800' }}>Business 101</Text></Text>
+      )}
 
       {COMPANIES.map(c => {
         const owned = owns(c.id);
-        const gated = !s.educations.some(e=>e.id==='BUSINESS_101');
+        const gated = !hasEdu;
+        const ownedCompany = companies.find(x=>x.id===c.id);
         return (
           <View key={c.id} style={{ backgroundColor:'#fff', borderRadius:14, borderWidth:1, borderColor:'#e5e7eb', padding:14 }}>
             <Text style={{ fontWeight:'900' }}>{c.name}</Text>
             <Text style={{ color:'#16a34a', fontWeight:'800' }}>{owned ? 'Owned' : `$${c.price}`}</Text>
             <Text style={{ color:'#6b7280' }}>Base revenue ~ ${c.baseRev}/week</Text>
             <Pressable
-              onPress={()=>start(c.id)}
+              onPress={()=>{ startCompany(c.id); show(`Started ${c.name}`); }}
               disabled={owned || gated || money < c.price}
               style={{ alignSelf:'flex-start', marginTop:8, backgroundColor:(owned||gated||money<c.price)?'#e5e7eb':'#16a34a', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}
             >
@@ -65,18 +43,32 @@ export default function BusinessApp() {
                 {owned ? 'Owned' : gated ? 'Need Business 101' : 'Start'}
               </Text>
             </Pressable>
-
-            {owned && (
-              <View style={{ flexDirection:'row', gap:8, marginTop:10 }}>
-                <Pressable onPress={()=>hire(c.id)} style={{ backgroundColor:'#2563eb', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
-                  <Text style={{ color:'#fff', fontWeight:'800' }}>Hire</Text>
-                </Pressable>
-                <Pressable onPress={()=>upgrade(c.id,'marketing')} style={{ backgroundColor:'#f59e0b', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
-                  <Text style={{ color:'#111827', fontWeight:'800' }}>Marketing</Text>
-                </Pressable>
-                <Pressable onPress={()=>upgrade(c.id,'automation')} style={{ backgroundColor:'#a78bfa', paddingHorizontal:12, paddingVertical:8, borderRadius:10 }}>
-                  <Text style={{ color:'#111827', fontWeight:'800' }}>Efficiency</Text>
-                </Pressable>
+            {owned && ownedCompany && (
+              <View style={{ gap:8, marginTop:10 }}>
+                <View style={{ flexDirection:'row', flexWrap:'wrap', gap:8 }}>
+                  <Pressable onPress={()=>{ hireEmployee(c.id); show('Hired 1 employee'); }} disabled={ownedCompany.employees>=25} style={{ backgroundColor:'#2563eb', paddingHorizontal:12, paddingVertical:8, borderRadius:10, opacity:ownedCompany.employees>=25?0.5:1 }}>
+                    <Text style={{ color:'#fff', fontWeight:'800' }}>Hire (+$100/-$40)</Text>
+                  </Pressable>
+                  <Pressable onPress={()=>{ upgradeMarketing(c.id,1); show('Marketing upgraded (S)'); }} disabled={ownedCompany.marketingLevel>=1} style={{ backgroundColor:'#f59e0b', paddingHorizontal:12, paddingVertical:8, borderRadius:10, opacity:ownedCompany.marketingLevel>=1?0.5:1 }}>
+                    <Text style={{ color:'#111827', fontWeight:'800' }}>Marketing S ($500)</Text>
+                  </Pressable>
+                  <Pressable onPress={()=>{ upgradeMarketing(c.id,2); show('Marketing upgraded (M)'); }} disabled={ownedCompany.marketingLevel>=2} style={{ backgroundColor:'#f59e0b', paddingHorizontal:12, paddingVertical:8, borderRadius:10, opacity:ownedCompany.marketingLevel>=2?0.5:1 }}>
+                    <Text style={{ color:'#111827', fontWeight:'800' }}>Marketing M ($1000)</Text>
+                  </Pressable>
+                  <Pressable onPress={()=>{ upgradeMarketing(c.id,3); show('Marketing upgraded (L)'); }} disabled={ownedCompany.marketingLevel>=3} style={{ backgroundColor:'#f59e0b', paddingHorizontal:12, paddingVertical:8, borderRadius:10, opacity:ownedCompany.marketingLevel>=3?0.5:1 }}>
+                    <Text style={{ color:'#111827', fontWeight:'800' }}>Marketing L ($2000)</Text>
+                  </Pressable>
+                  <Pressable onPress={()=>{ automateCompany(c.id); show('Automation purchased'); }} disabled={ownedCompany.automated} style={{ backgroundColor:'#a78bfa', paddingHorizontal:12, paddingVertical:8, borderRadius:10, opacity:ownedCompany.automated?0.5:1 }}>
+                    <Text style={{ color:'#111827', fontWeight:'800' }}>Automation ($5000)</Text>
+                  </Pressable>
+                  <Pressable onPress={()=>{ upgradeCashflow(c.id); show('Cashflow upgrade'); }} disabled={ownedCompany.cashflowLevel>=1} style={{ backgroundColor:'#4ade80', paddingHorizontal:12, paddingVertical:8, borderRadius:10, opacity:ownedCompany.cashflowLevel>=1?0.5:1 }}>
+                    <Text style={{ color:'#111827', fontWeight:'800' }}>Cashflow ($3000)</Text>
+                  </Pressable>
+                </View>
+                <Text style={{ color:'#6b7280' }}>Hire adds $100 revenue / $40 cost per week (max 25).</Text>
+                <Text style={{ color:'#6b7280' }}>Marketing boosts revenue; higher tiers stack.</Text>
+                <Text style={{ color:'#6b7280' }}>Automation cuts costs by $20/week once.</Text>
+                <Text style={{ color:'#6b7280' }}>Cashflow adds $200 revenue/week once.</Text>
               </View>
             )}
           </View>

--- a/src/apps/RelationsApp.tsx
+++ b/src/apps/RelationsApp.tsx
@@ -1,4 +1,5 @@
-import { View, Text, Pressable } from 'react-native';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { useState } from 'react';
 import { useGame } from '../store';
 
 export default function RelationsApp() {
@@ -6,12 +7,13 @@ export default function RelationsApp() {
   const current = relationship.currentPartnerId
     ? relationship.partners.find(p => p.id === relationship.currentPartnerId)
     : undefined;
+  const [viewing, setViewing] = useState<typeof relationship.partners[number] | undefined>();
 
   return (
-    <View style={{ padding:16, gap:12 }}>
+    <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
       <Text style={{ fontSize:18, fontWeight:'900' }}>Contacts</Text>
 
-      {current ? (
+      {current && !viewing ? (
         <View style={{ backgroundColor:'#fff', borderRadius:14, borderWidth:1, borderColor:'#eef2f7', padding:14 }}>
           <Text>Partner: {current?.name}</Text>
           <Text>Relationship: {relationship.relationshipPoints}/100</Text>
@@ -21,12 +23,21 @@ export default function RelationsApp() {
             <Pressable onPress={breakUp} style={{ backgroundColor:'#ef4444', padding:10, borderRadius:10 }}><Text style={{ color:'#fff' }}>Break up</Text></Pressable>
           </View>
         </View>
+      ) : viewing ? (
+        <View style={{ backgroundColor:'#fff', borderRadius:14, borderWidth:1, borderColor:'#eef2f7', padding:14, gap:8 }}>
+          <Text style={{ fontWeight:'800' }}>{viewing.name}</Text>
+          <Text style={{ color:'#6b7280' }}>Charm {viewing.charm} • Drama {viewing.drama}</Text>
+          <View style={{ flexDirection:'row', gap:10, marginTop:10, flexWrap:'wrap' }}>
+            <Pressable onPress={()=>{ setPartner(viewing.id); setViewing(undefined); }} style={{ backgroundColor:'#16a34a', padding:10, borderRadius:10 }}><Text style={{ color:'#fff', fontWeight:'800' }}>Select</Text></Pressable>
+            <Pressable onPress={()=>setViewing(undefined)} style={{ backgroundColor:'#e5e7eb', padding:10, borderRadius:10 }}><Text>Back</Text></Pressable>
+          </View>
+        </View>
       ) : (
         <>
           {relationship.partners.map(p => (
             <Pressable
               key={p.id}
-              onPress={()=>setPartner(p.id)}
+              onPress={()=>setViewing(p)}
               style={{ backgroundColor:'#fff', borderRadius:14, borderWidth:1, borderColor:'#eef2f7', padding:14 }}
             >
               <Text style={{ fontWeight:'800' }}>{p.name}</Text>
@@ -35,6 +46,6 @@ export default function RelationsApp() {
           ))}
         </>
       )}
-    </View>
+    </ScrollView>
   );
 }

--- a/src/apps/StudyApp.tsx
+++ b/src/apps/StudyApp.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable } from 'react-native';
+import { View, Text, Pressable, ScrollView } from 'react-native';
 import { useGame } from '../store';
 
 function Row({ label, value }:{ label:string; value:string|number }) {
@@ -10,7 +10,7 @@ export default function StudyApp() {
   const enrolled = educations.find(e => e.id === enrolledEducationId);
 
   return (
-    <View style={{ padding:16, gap:12 }}>
+    <ScrollView contentContainerStyle={{ padding:16, gap:12 }}>
       <Text style={{ fontSize:18, fontWeight:'900' }}>Education</Text>
 
       {enrolled ? (
@@ -42,6 +42,6 @@ export default function StudyApp() {
           ))}
         </>
       )}
-    </View>
+    </ScrollView>
   );
 }

--- a/src/data/companies.ts
+++ b/src/data/companies.ts
@@ -1,0 +1,7 @@
+export const COMPANIES = [
+  { id:'FACTORY', name:'Factory', price:10000, baseRev:400 },
+  { id:'RESTAURANT', name:'Restaurant', price:6000, baseRev:250 },
+  { id:'AI_CO', name:'AI Company', price:15000, baseRev:600 },
+  { id:'REAL_ESTATE', name:'Real Estate', price:22000, baseRev:800 },
+  { id:'BANK', name:'Bank', price:30000, baseRev:1200 },
+];

--- a/src/data/crypto.ts
+++ b/src/data/crypto.ts
@@ -1,0 +1,9 @@
+export const COINS = ['BTC','ETH','SOL','BNB','XRP'] as const;
+export type Coin = typeof COINS[number];
+
+export const MINERS = [
+  { id:'USB_MINER', name:'USB Miner', price:120, hash:5 },
+  { id:'GPU_RIG', name:'GPU Rig', price:800, hash:40 },
+  { id:'ASIC_LITE', name:'ASIC Lite', price:1600, hash:90 },
+  { id:'ASIC_PRO', name:'ASIC Pro', price:3200, hash:200 },
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,16 @@ export interface Education {
 
 export interface Home { id: string; name: string; weeklyEnergy: number; weeklyHappiness: number; rentPerMonth: number; furnitureSlots: number; }
 export interface Furniture { id: string; name: string; energyBonus: number; happinessBonus: number; }
-export interface Company { id: string; name: string; employees: number; revenuePerWeek: number; costPerWeek: number; }
+export interface Company {
+  id: string;
+  name: string;
+  employees: number;
+  revenuePerWeek: number;
+  costPerWeek: number;
+  marketingLevel: number;
+  automated: boolean;
+  cashflowLevel: number;
+}
 export interface Loan { id: string; principal: number; annualRate: number; monthlyPayment: number; }
 export interface Time { week: number; year: number; }
 
@@ -93,6 +102,10 @@ export interface GameState {
   educationWeeksLeft?: number;
 
   companies: Company[];
+
+  cryptoTarget: string;
+  cryptoMiners: { id: string; count: number }[];
+  cryptoPortfolio: Record<string, number>;
 
   hasUSB: boolean;
   darkWebUnlocked: boolean;


### PR DESCRIPTION
## Summary
- allow scrolling through education and contacts lists
- expand business management with hiring limits and upgrade actions
- link crypto mining and stock prices to dynamic markets with simple charts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Type errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689922cb08b4832cbb9e7b0ed533f5fe