### PR TITLE
fix: use ExpoRouter root component

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,8 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { ExpoRoot } from 'expo-router';
 
-export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
+export function App() {
+  const ctx = require.context('./app');
+  return <ExpoRoot context={ctx} />;
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+export default App;


### PR DESCRIPTION
## Summary
- render Expo Router root component in `App.tsx`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc8833bb4832c847ec63189f958c6